### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ The WavefrontSender interface has two implementations.<br/>
   /* set this if you want to override the default SocketFactory */
   builder.socketFactory(<SocketFactory>);
   
-  /* set this if you want to change the default flush interval of 5 seconds */
+  /* The flushing interval controls how often the WavefrontSender sends data to the Wavefront service.
+   * Set this if you want to change the default flush interval of 5 seconds. 
+   */
   builder.flushIntervalSeconds(2);
   
   WavefrontProxyClient wavefrontProxyClient = builder.build();
@@ -52,13 +54,15 @@ The WavefrontSender interface has two implementations.<br/>
   WavefrontDirectIngestionClient.Builder builder = 
   new WavefrontDirectIngestionClient.Builder(wavefrontServer, token);
  
-  // set this if you want to change the defualt max queue size of 50,000
+  /* set this if you want to change the defualt max queue size of 50,000 */
   builder.maxQueueSize(100_000);
  
-  // set this if you want to change the default batch size of 10,000
+  /* set this if you want to change the default batch size of 10,000 */
   builder.batchSize(20_000);
  
-  // set this if you want to change the default flush interval value of 1 seconds
+  /* The flushing interval controls how often the WavefrontSender sends data to the Wavefront service.
+   * Set this if you want to change the default flush interval value of 1 seconds 
+   */
   builder.flushIntervalSeconds(2);
    
   WavefrontDirectIngestionClient wavefrontDirectIngestionClient = builder.build();


### PR DESCRIPTION
Clarify what flushing interval means (so it can be compared to reporting interval in T2 SDKs).

Also, is default flushing interval for proxy really 5 seconds? Why is it different for direct ingestion? And different from documented default for `pushFlushInterval` in `wavefront.conf`?